### PR TITLE
Feature/reserve dashboard

### DIFF
--- a/frontend/src/app/app/Reserve/components/chart.tsx
+++ b/frontend/src/app/app/Reserve/components/chart.tsx
@@ -49,7 +49,7 @@ const ReserveChart = () => {
     }));
   };
 
-  const CheckmarkIcon = ({ backgroundColor }: { backgroundColor?: string }) => {
+  const CheckmarkIcon = ({ backgroundColor, border }: { backgroundColor?: string, border?: string }) => {
     return (
       <svg
         xmlns="http://www.w3.org/2000/svg"
@@ -59,7 +59,7 @@ const ReserveChart = () => {
         strokeWidth={2}
         strokeLinecap="round"
         strokeLinejoin="round"
-        style={{ backgroundColor, width: 20, height: 20, borderRadius: "5px" }}
+        style={{ backgroundColor, width: 20, height: 20, borderRadius: "5px", border }}
       >
         <path d="M20 6 9 17l-5-5" />
       </svg>
@@ -76,12 +76,16 @@ const ReserveChart = () => {
         {payload.map((entry, index) => (
           <li
             key={`item-${index}`}
-            className="w-fit text-black inline-flex items-center text-xs gap-2"
+            className="w-fit text-black inline-flex items-center text-xs gap-2 cursor-pointer"
             onClick={() =>
               toggleLineVisibility(entry.value as "Borrow TVL" | "Borrow APY")
             }
           >
-            <CheckmarkIcon backgroundColor={entry.color} />
+            {lineVisibility[entry.value as "Borrow TVL" | "Borrow APY"] ? (
+              <CheckmarkIcon backgroundColor={entry.color} />
+            ) : (
+              <CheckmarkIcon border="1px solid #E5E7EB"/>
+            )}
             {entry.value}
           </li>
         ))}

--- a/frontend/src/app/app/Reserve/components/chart.tsx
+++ b/frontend/src/app/app/Reserve/components/chart.tsx
@@ -23,8 +23,16 @@ const data = [
 ];
 
 const ReserveChart = () => {
-  const [mode, setMode] = useState("Borrow");
+  const [mode, setMode] = useState<"Borrow" | "Supply">("Borrow");
   const [period, setPeriod] = useState("15D");
+
+  const [lineVisibility, setLineVisibility] = useState<{
+    "Borrow TVL": boolean;
+    "Borrow APY": boolean;
+  }>({
+    "Borrow TVL": true,
+    "Borrow APY": true,
+  });
 
   const handleModeChange = () => {
     setMode(mode === "Borrow" ? "Supply" : "Borrow");
@@ -32,6 +40,13 @@ const ReserveChart = () => {
 
   const handlePeriodChange = (newPeriod: string) => {
     setPeriod(newPeriod);
+  };
+
+  const toggleLineVisibility = (lineKey: "Borrow TVL" | "Borrow APY") => {
+    setLineVisibility((prev) => ({
+      ...prev,
+      [lineKey]: !prev[lineKey],
+    }));
   };
 
   const CheckmarkIcon = ({ backgroundColor }: { backgroundColor?: string }) => {
@@ -59,7 +74,13 @@ const ReserveChart = () => {
     return (
       <ul className="flex items-center justify-evenly mt-6">
         {payload.map((entry, index) => (
-          <li key={`item-${index}`} className="w-fit text-black inline-flex items-center text-xs gap-2">
+          <li
+            key={`item-${index}`}
+            className="w-fit text-black inline-flex items-center text-xs gap-2"
+            onClick={() =>
+              toggleLineVisibility(entry.value as "Borrow TVL" | "Borrow APY")
+            }
+          >
             <CheckmarkIcon backgroundColor={entry.color} />
             {entry.value}
           </li>
@@ -133,24 +154,28 @@ const ReserveChart = () => {
               ],
             })}
           />
-          <Line
-            yAxisId="left"
-            type="monotone"
-            dataKey={`${mode} TVL`}
-            stroke="#4CAF50"
-            strokeWidth={2}
-            legendType="square"
-            dot={false}
-          />
-          <Line
-            yAxisId="right"
-            type="monotone"
-            dataKey={`${mode} APY`}
-            stroke="#F44336"
-            strokeWidth={2}
-            legendType="square"
-            dot={false}
-          />
+          {lineVisibility[`${mode} TVL` as "Borrow TVL" | "Borrow APY"] && (
+            <Line
+              yAxisId="left"
+              type="monotone"
+              dataKey={`${mode} TVL`}
+              stroke="#4CAF50"
+              strokeWidth={2}
+              legendType="square"
+              dot={false}
+            />
+          )}
+          {lineVisibility[`${mode} APY` as "Borrow TVL" | "Borrow APY"] && (
+            <Line
+              yAxisId="right"
+              type="monotone"
+              dataKey={`${mode} APY`}
+              stroke="#F44336"
+              strokeWidth={2}
+              legendType="square"
+              dot={false}
+            />
+          )}
         </LineChart>
       </ResponsiveContainer>
     </div>

--- a/frontend/src/app/app/Reserve/components/chart.tsx
+++ b/frontend/src/app/app/Reserve/components/chart.tsx
@@ -24,7 +24,7 @@ const data = [
 
 const ReserveChart = () => {
   const [mode, setMode] = useState<"Borrow" | "Supply">("Borrow");
-  const [period, setPeriod] = useState("15D");
+  const [period, setPeriod] = useState(15);
 
   const [lineVisibility, setLineVisibility] = useState<{
     "Borrow TVL": boolean;
@@ -38,7 +38,11 @@ const ReserveChart = () => {
     setMode(mode === "Borrow" ? "Supply" : "Borrow");
   };
 
-  const handlePeriodChange = (newPeriod: string) => {
+  const handlePeriodChange = (newPeriod: number) => {
+    if (period >= 365) {
+      setPeriod(15);
+      return;
+    }
     setPeriod(newPeriod);
   };
 
@@ -107,9 +111,9 @@ const ReserveChart = () => {
           <span className="mr-2">Period:</span>
           <button
             className="inline-flex py-2 px-2 rounded-3xl border border-black w-fit items-center gap-1 text-black font-normal text-sm lg:text-[15px]"
-            onClick={() => handlePeriodChange("15D")}
+            onClick={() => handlePeriodChange(period * 2)}
           >
-            Period {period}
+            Period {period}D
             <ChevronDownIcon />
           </button>
         </div>

--- a/frontend/src/app/app/Reserve/components/chart.tsx
+++ b/frontend/src/app/app/Reserve/components/chart.tsx
@@ -1,0 +1,160 @@
+import { ChevronDownIcon } from "lucide-react";
+import { useState } from "react";
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from "recharts";
+
+const data = [
+  { date: "13/6", "Borrow TVL": 271.09, "Borrow APY": 27.04 },
+  { date: "13/6", "Borrow TVL": 242.39, "Borrow APY": 27.83 },
+  { date: "13/6", "Borrow TVL": 258.14, "Borrow APY": 27.45 },
+  { date: "13/6", "Borrow TVL": 266.32, "Borrow APY": 26.78 },
+  { date: "13/6", "Borrow TVL": 240.37, "Borrow APY": 27.93 },
+  { date: "13/6", "Borrow TVL": 251.41, "Borrow APY": 27.24 },
+  { date: "13/6", "Borrow TVL": 249.41, "Borrow APY": 21.24 },
+  { date: "13/6", "Borrow TVL": 236.44, "Borrow APY": 28.15 },
+];
+
+const ReserveChart = () => {
+  const [mode, setMode] = useState("Borrow");
+  const [period, setPeriod] = useState("15D");
+
+  const handleModeChange = () => {
+    setMode(mode === "Borrow" ? "Supply" : "Borrow");
+  };
+
+  const handlePeriodChange = (newPeriod: string) => {
+    setPeriod(newPeriod);
+  };
+
+  const CheckmarkIcon = ({ backgroundColor }: { backgroundColor?: string }) => {
+    return (
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="white"
+        strokeWidth={2}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        style={{ backgroundColor, width: 20, height: 20, borderRadius: "5px" }}
+      >
+        <path d="M20 6 9 17l-5-5" />
+      </svg>
+    );
+  };
+
+  const renderLegend = (data: {
+    payload: { value: string; color: string }[];
+  }) => {
+    const { payload } = data;
+
+    return (
+      <ul className="flex items-center justify-evenly mt-6">
+        {payload.map((entry, index) => (
+          <li key={`item-${index}`} className="w-fit text-black inline-flex items-center text-xs gap-2">
+            <CheckmarkIcon backgroundColor={entry.color} />
+            {entry.value}
+          </li>
+        ))}
+      </ul>
+    );
+  };
+
+  return (
+    <div>
+      <div className="flex justify-between mb-4">
+        <button
+          className="inline-flex py-2 px-2 rounded-3xl border border-black w-fit items-center gap-1 text-black font-normal text-sm lg:text-[15px]"
+          onClick={handleModeChange}
+        >
+          {mode}
+          <ChevronDownIcon />
+        </button>
+        <div className="flex items-center">
+          <span className="mr-2">Period:</span>
+          <button
+            className="inline-flex py-2 px-2 rounded-3xl border border-black w-fit items-center gap-1 text-black font-normal text-sm lg:text-[15px]"
+            onClick={() => handlePeriodChange("15D")}
+          >
+            Period {period}
+            <ChevronDownIcon />
+          </button>
+        </div>
+      </div>
+      <ResponsiveContainer width="100%" height={400}>
+        <LineChart data={data}>
+          <XAxis
+            dataKey="date"
+            className="font-bold text-sm text-black"
+            tickLine={false}
+            tickMargin={10}
+            tickSize={10}
+            padding={{ left: 30, right: 30 }}
+          />
+          <YAxis
+            yAxisId="left"
+            type="number"
+            domain={[0.0, 300.0]}
+            className="text-[10px]"
+            tickFormatter={(value) => `${parseFloat(value.toFixed(2))}M`}
+            tickCount={6}
+            tickLine={false}
+            tickMargin={10}
+            allowDecimals
+            axisLine={false}
+          />
+          <YAxis
+            yAxisId="right"
+            type="number"
+            domain={[-40, 60]}
+            orientation="right"
+            className="text-[10px]"
+            tickFormatter={(value) => `${parseFloat(value.toFixed(2))}%`}
+            tickCount={6}
+            tickLine={false}
+            tickMargin={10}
+            axisLine={false}
+          />
+          <CartesianGrid strokeDasharray="3 3" vertical={false} opacity="0.5" />
+          <Tooltip />
+          <Legend
+            content={renderLegend({
+              payload: [
+                { value: `${mode} TVL`, color: "#4CAF50" },
+                { value: `${mode} APY`, color: "#F44336" },
+              ],
+            })}
+          />
+          <Line
+            yAxisId="left"
+            type="monotone"
+            dataKey={`${mode} TVL`}
+            stroke="#4CAF50"
+            strokeWidth={2}
+            legendType="square"
+            dot={false}
+          />
+          <Line
+            yAxisId="right"
+            type="monotone"
+            dataKey={`${mode} APY`}
+            stroke="#F44336"
+            strokeWidth={2}
+            legendType="square"
+            dot={false}
+          />
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  );
+};
+
+export default ReserveChart;

--- a/frontend/src/app/app/Reserve/components/dashboard.tsx
+++ b/frontend/src/app/app/Reserve/components/dashboard.tsx
@@ -2,6 +2,7 @@ import { ChevronDownIcon, CogIcon } from "lucide-react";
 import Image from "next/image";
 import { useState } from "react";
 import Dropdown from "./dropdown";
+import ReserveChart from "./chart";
 
 interface TokenInfo {
   tokenReserved: {
@@ -40,6 +41,32 @@ const Dashboard: React.FC<TokenInfo> = ({ tokenReserved }) => {
   const options = [
     { label: "Supply", value: "supply" },
     { label: "Borrow", value: "borrow" },
+  ];
+
+  const borrowInfo = [
+    {
+      label: "Total Supplied",
+      value: "20.43M",
+    },
+    {
+      label: "Borrow APY",
+      value: "30%",
+    },
+    {
+      label: "Borrow Cap",
+      value: "53.02%",
+    },
+  ];
+
+  const liquiditationInfo = [
+    {
+      label: "Max LTV",
+      value: "10.00%",
+    },
+    {
+      label: "Liquidation LTV",
+      value: "30.34%",
+    },
   ];
 
   const [selectedProtocol, setSelectedProtocol] = useState(options[0].label);
@@ -176,6 +203,24 @@ const Dashboard: React.FC<TokenInfo> = ({ tokenReserved }) => {
           </p>
         </div>
       </div>
+      <br />
+      <section className="bg-white max-w-[1064px] rounded-[20px] p-5 flex flex-col gap-4 lg:gap-8">
+        <ReserveChart />
+        <hr />
+        <h4 className="font-semibold text-base lg:text-xl text-black">Borrow Info</h4>
+        <div className="bg-white max-w-4xl grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-1">
+          {borrowInfo.map((metric, index) => (
+            <MetricCard key={index} label={metric.label} value={metric.value} />
+          ))}
+        </div>
+        <hr />
+        <h4 className="font-semibold text-base lg:text-xl text-black">Liquidation Info</h4>
+        <div className="bg-white max-w-4xl grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
+          {liquiditationInfo.map((metric, index) => (
+            <MetricCard key={index} label={metric.label} value={metric.value} />
+          ))}
+        </div>
+      </section>
     </>
   );
 };

--- a/frontend/src/app/app/Reserve/components/dashboard.tsx
+++ b/frontend/src/app/app/Reserve/components/dashboard.tsx
@@ -122,7 +122,7 @@ const Dashboard: React.FC<TokenInfo> = ({ tokenReserved }) => {
           {tokenReserved.symbol}
         </span>
       </div>
-      <div className="flex flex-col md:flex-row gap-4 lg:gap-8">
+      <div className="flex flex-col md:flex-row gap-4 lg:gap-8 max-w-[1093px] md:justify-between">
         <div className="bg-white border rounded-[20px] max-w-[650px] h-[412px] grid grid-cols-2 gap-3 py-5 px-5">
           {coinMetricsData.map((metric, index) => (
             <MetricCard key={index} label={metric.label} value={metric.value} />
@@ -204,7 +204,7 @@ const Dashboard: React.FC<TokenInfo> = ({ tokenReserved }) => {
         </div>
       </div>
       <br />
-      <section className="bg-white max-w-[1064px] rounded-[20px] p-5 flex flex-col gap-4 lg:gap-8">
+      <section className="bg-white max-w-[1093px] rounded-[20px] p-5 flex flex-col gap-4 lg:gap-8">
         <ReserveChart />
         <hr />
         <h4 className="font-semibold text-base lg:text-xl text-black">Borrow Info</h4>

--- a/frontend/src/app/app/Reserve/components/dashboard.tsx
+++ b/frontend/src/app/app/Reserve/components/dashboard.tsx
@@ -1,0 +1,183 @@
+import { ChevronDownIcon, CogIcon } from "lucide-react";
+import Image from "next/image";
+import { useState } from "react";
+import Dropdown from "./dropdown";
+
+interface TokenInfo {
+  tokenReserved: {
+    symbol: string;
+    address: string;
+    decimals: number;
+    icon: string;
+    balance: number;
+    availableLiquidity: string;
+    supply: string;
+    utilization: string;
+    totalBorrowed: string;
+  };
+}
+
+const Dashboard: React.FC<TokenInfo> = ({ tokenReserved }) => {
+  const coinMetricsData = [
+    {
+      label: `${tokenReserved.symbol} Supplied`,
+      value: tokenReserved.supply,
+    },
+    {
+      label: "Available liquidity",
+      value: tokenReserved.availableLiquidity,
+    },
+    {
+      label: "Utilization",
+      value: tokenReserved.utilization,
+    },
+    {
+      label: "Total Borrowed",
+      value: tokenReserved.totalBorrowed,
+    },
+  ];
+
+  const options = [
+    { label: "Supply", value: "supply" },
+    { label: "Borrow", value: "borrow" },
+  ];
+
+  const [selectedProtocol, setSelectedProtocol] = useState(options[0].label);
+  const [inputBalance, setInputBalance] = useState(0);
+
+  const handleDropdownChange = (value: string) => {
+    setSelectedProtocol(value);
+  };
+
+  const balancePercentages = Array.from({ length: 4 }, (_, index) => ({
+    percentage: (index + 1) * 25,
+  }));
+
+  const handlePercentageClick = (percentage: number) => {
+    const balance = tokenReserved.balance;
+    const newAmount = (balance * percentage) / 100;
+    setInputBalance(newAmount);
+  };
+
+  const handleProtocolSubmit = () => {
+    console.log("Protocol submitted:", selectedProtocol);
+    console.log("Input balance:", inputBalance);
+  };
+
+  const MetricCard = ({ label, value }: { label: string; value: string }) => (
+    <div className="relative flex flex-col justify-center bg-smoke-white w-[290px] h-[150px] rounded-2xl pl-4 lg:pl-6">
+      <p className="text-gray-500 text-xs">{label}</p>
+      <p className="text-black font-normal text-2xl md:text-4xl pt-2">
+        {value}
+      </p>
+    </div>
+  );
+
+  return (
+    <>
+      <div className="flex text-black items-center gap-3 mb-6">
+        <div
+          onClick={() => window.history.back()}
+          className="cursor-pointer w-10 h-10 border border-black rounded-full flex items-center justify-center"
+        >
+          <span className="w-5 font-semibold">&larr;</span>
+        </div>
+        <h1 className="md:text-3xl md:font-semibold">
+          {tokenReserved.symbol} Reserve
+        </h1>
+        <span className="py-1 px-3 flex items-center gap-1 text-sm text-black/50 rounded-3xl border border-black/50">
+          <Image
+            src={tokenReserved.icon}
+            alt={tokenReserved.symbol}
+            width={20}
+            height={20}
+          />
+          {tokenReserved.symbol}
+        </span>
+      </div>
+      <div className="flex flex-col md:flex-row gap-4 lg:gap-8">
+        <div className="bg-white border rounded-[20px] max-w-[650px] h-[412px] grid grid-cols-2 gap-3 py-5 px-5">
+          {coinMetricsData.map((metric, index) => (
+            <MetricCard key={index} label={metric.label} value={metric.value} />
+          ))}
+        </div>
+        <div className="bg-white border rounded-[20px] w-[402px] h-[412px] p-4">
+          <div className="w-fit ml-auto">
+            <Dropdown
+              options={options}
+              selected={selectedProtocol}
+              selectedClassname="bg-white text-black border border-black"
+              dropdownClassname="bg-white text-black border border-black"
+              onSelect={handleDropdownChange}
+            />
+          </div>
+          <br />
+          <hr />
+          <br />
+          <div className="w-[368px] h-[239px] rounded-[10px] bg-black/5 p-3">
+            <div className="w-full flex justify-between">
+              <h4 className="text-xs font-normal text-black">Your supply</h4>
+              <div className="flex flex-col text-[8px] gap-1 leading-3 font-normal text-black">
+                <span className="text-right">Priority fee</span>
+                <p className="inline-flex justify-center items-center gap-1 w-[88px] h-[21px] rounded-3xl bg-black/10">
+                  Minimum <CogIcon size={15} />
+                </p>
+              </div>
+            </div>
+            <br />
+            <div className="flex justify-between relative mt-5 md:mt-8">
+              <button
+                type="button"
+                className="inline-flex py-2 px-2 rounded-[10px] max-w-[121px] items-center gap-1 bg-black/10 text-black font-semibold text-sm lg:text-xl"
+              >
+                <Image
+                  src={tokenReserved.icon}
+                  alt={tokenReserved.symbol}
+                  width={20}
+                  height={20}
+                />
+                {tokenReserved.symbol}
+                <ChevronDownIcon />
+              </button>
+              <label htmlFor="amount" className="relative w-48 h-[21px]">
+                <input
+                  type="text"
+                  name="amount"
+                  id="amount"
+                  placeholder="0"
+                  dir="rtl"
+                  maxLength={8}
+                  onChange={(e) => setInputBalance(parseFloat(e.target.value))}
+                  className="w-full bg-transparent outline-none focus:outline-none text-xl lg:text-3xl font-semibold text-black/50"
+                />
+              </label>
+            </div>
+            <br />
+            <p className="text-black font-normal text-sm mb-2">
+              Available: {tokenReserved.balance}
+            </p>
+            <div className="w-full inline-flex gap-1 justify-end">
+              {balancePercentages.map((percentage, index) => (
+                <span
+                  key={index}
+                  className="inline-flex rounded-sm w-[31px] h-5 items-center justify-center bg-black/10 text-black font-normal text-[8px]"
+                  onClick={() => handlePercentageClick(percentage.percentage)}
+                >
+                  {percentage.percentage}%
+                </span>
+              ))}
+            </div>
+          </div>
+          <p
+            className="h-[42px] bg-black rounded-3xl text-base w-full inline-flex items-center justify-center mt-3"
+            onClick={handleProtocolSubmit}
+          >
+            {selectedProtocol}
+          </p>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default Dashboard;

--- a/frontend/src/app/app/Reserve/components/dashboard.tsx
+++ b/frontend/src/app/app/Reserve/components/dashboard.tsx
@@ -95,7 +95,7 @@ const Dashboard: React.FC<TokenInfo> = ({ tokenReserved }) => {
   const MetricCard = ({ label, value }: { label: string; value: string }) => (
     <div className="relative flex flex-col justify-center bg-smoke-white w-[290px] h-[150px] rounded-2xl pl-4 lg:pl-6">
       <p className="text-gray-500 text-xs">{label}</p>
-      <p className="text-black font-normal text-2xl md:text-4xl pt-2">
+      <p className="text-black font-normal text-2xl md:text-4xl pt-2 animate-fadeInBottom">
         {value}
       </p>
     </div>

--- a/frontend/src/app/app/Reserve/components/dashboard.tsx
+++ b/frontend/src/app/app/Reserve/components/dashboard.tsx
@@ -93,7 +93,7 @@ const Dashboard: React.FC<TokenInfo> = ({ tokenReserved }) => {
   };
 
   const MetricCard = ({ label, value }: { label: string; value: string }) => (
-    <div className="relative flex flex-col justify-center bg-black/10 w-[290px] h-[150px] rounded-2xl pl-4 lg:pl-6">
+    <div className="relative flex flex-col justify-center bg-[#F5F5F5] w-full h-[150px] rounded-2xl pl-4 lg:pl-6">
       <p className="text-gray-500 text-xs">{label}</p>
       <p className="text-black font-normal text-2xl md:text-4xl pt-2 animate-fadeInBottom">
         {value}
@@ -124,7 +124,7 @@ const Dashboard: React.FC<TokenInfo> = ({ tokenReserved }) => {
         </span>
       </div>
       <div className="flex flex-col md:flex-row gap-4 lg:gap-8 w-full md:justify-between">
-        <div className="bg-white border rounded-[20px] max-w-[650px] h-[412px] grid grid-cols-2 gap-3 py-5 px-5">
+        <div className="bg-white border rounded-[20px] w-full md:w-[650px] lg:w-[90%] grid grid-cols-2 place-content-center place-items-center gap-3 md:gap-6 lg:gap-8 py-5 px-5">
           {coinMetricsData.map((metric, index) => (
             <MetricCard key={index} label={metric.label} value={metric.value} />
           ))}
@@ -208,14 +208,18 @@ const Dashboard: React.FC<TokenInfo> = ({ tokenReserved }) => {
       <section className="bg-white w-full border rounded-[20px] p-5 flex flex-col gap-4 lg:gap-8">
         <ReserveChart />
         <hr />
-        <h4 className="font-semibold text-base lg:text-xl text-black">Borrow Info</h4>
-        <div className="bg-white max-w-4xl grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-1">
+        <h4 className="font-semibold text-base lg:text-xl text-black">
+          Borrow Info
+        </h4>
+        <div className="bg-white max-w-4xl grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
           {borrowInfo.map((metric, index) => (
             <MetricCard key={index} label={metric.label} value={metric.value} />
           ))}
         </div>
         <hr />
-        <h4 className="font-semibold text-base lg:text-xl text-black">Liquidation Info</h4>
+        <h4 className="font-semibold text-base lg:text-xl text-black">
+          Liquidation Info
+        </h4>
         <div className="bg-white max-w-4xl grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
           {liquiditationInfo.map((metric, index) => (
             <MetricCard key={index} label={metric.label} value={metric.value} />

--- a/frontend/src/app/app/Reserve/components/dashboard.tsx
+++ b/frontend/src/app/app/Reserve/components/dashboard.tsx
@@ -93,7 +93,7 @@ const Dashboard: React.FC<TokenInfo> = ({ tokenReserved }) => {
   };
 
   const MetricCard = ({ label, value }: { label: string; value: string }) => (
-    <div className="relative flex flex-col justify-center bg-smoke-white w-[290px] h-[150px] rounded-2xl pl-4 lg:pl-6">
+    <div className="relative flex flex-col justify-center bg-black/10 w-[290px] h-[150px] rounded-2xl pl-4 lg:pl-6">
       <p className="text-gray-500 text-xs">{label}</p>
       <p className="text-black font-normal text-2xl md:text-4xl pt-2 animate-fadeInBottom">
         {value}
@@ -123,7 +123,7 @@ const Dashboard: React.FC<TokenInfo> = ({ tokenReserved }) => {
           {tokenReserved.symbol}
         </span>
       </div>
-      <div className="flex flex-col md:flex-row gap-4 lg:gap-8 max-w-[1093px] md:justify-between">
+      <div className="flex flex-col md:flex-row gap-4 lg:gap-8 w-full border md:justify-between">
         <div className="bg-white border rounded-[20px] max-w-[650px] h-[412px] grid grid-cols-2 gap-3 py-5 px-5">
           {coinMetricsData.map((metric, index) => (
             <MetricCard key={index} label={metric.label} value={metric.value} />
@@ -205,7 +205,7 @@ const Dashboard: React.FC<TokenInfo> = ({ tokenReserved }) => {
         </div>
       </div>
       <br />
-      <section className="bg-white max-w-[1093px] rounded-[20px] p-5 flex flex-col gap-4 lg:gap-8">
+      <section className="bg-white w-full border rounded-[20px] p-5 flex flex-col gap-4 lg:gap-8">
         <ReserveChart />
         <hr />
         <h4 className="font-semibold text-base lg:text-xl text-black">Borrow Info</h4>

--- a/frontend/src/app/app/Reserve/components/dashboard.tsx
+++ b/frontend/src/app/app/Reserve/components/dashboard.tsx
@@ -3,6 +3,7 @@ import Image from "next/image";
 import { useState } from "react";
 import Dropdown from "./dropdown";
 import ReserveChart from "./chart";
+import History from "./history/history";
 
 interface TokenInfo {
   tokenReserved: {
@@ -221,6 +222,8 @@ const Dashboard: React.FC<TokenInfo> = ({ tokenReserved }) => {
           ))}
         </div>
       </section>
+      <br />
+      <History />
     </>
   );
 };

--- a/frontend/src/app/app/Reserve/components/dashboard.tsx
+++ b/frontend/src/app/app/Reserve/components/dashboard.tsx
@@ -123,7 +123,7 @@ const Dashboard: React.FC<TokenInfo> = ({ tokenReserved }) => {
           {tokenReserved.symbol}
         </span>
       </div>
-      <div className="flex flex-col md:flex-row gap-4 lg:gap-8 w-full border md:justify-between">
+      <div className="flex flex-col md:flex-row gap-4 lg:gap-8 w-full md:justify-between">
         <div className="bg-white border rounded-[20px] max-w-[650px] h-[412px] grid grid-cols-2 gap-3 py-5 px-5">
           {coinMetricsData.map((metric, index) => (
             <MetricCard key={index} label={metric.label} value={metric.value} />

--- a/frontend/src/app/app/Reserve/components/dropdown.tsx
+++ b/frontend/src/app/app/Reserve/components/dropdown.tsx
@@ -1,0 +1,72 @@
+import React, { useState } from "react";
+import { ChevronDownIcon } from "lucide-react";
+
+interface DropdownProps {
+  options: { label: string; value: string }[];
+  selected: string;
+  selectedClassname?: string;
+  dropdownClassname?: string;
+  onSelect: (value: string) => void;
+}
+
+const Dropdown: React.FC<DropdownProps> = ({
+  options,
+  selected,
+  selectedClassname,
+  dropdownClassname,
+  onSelect,
+}) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const toggleDropdown = () => {
+    setIsOpen(!isOpen);
+  };
+
+  const handleOptionSelect = (value: string) => {
+    onSelect(value);
+    setIsOpen(false);
+  };
+
+  return (
+    <div className="relative inline-block text-left">
+      <div>
+        <button
+          type="button"
+          className={`inline-flex py-2 px-4 rounded-3xl w-full ${
+            selectedClassname ?? "bg-black text-white"
+          }`}
+          onClick={toggleDropdown}
+        >
+          {selected}
+          <ChevronDownIcon
+            className={`-mr-1 ml-2 h-5 w-5 transition-transform duration-300 ${
+              isOpen ? "transform rotate-180" : ""
+            }`}
+          />
+        </button>
+      </div>
+
+      {isOpen && (
+        <div
+          className={`origin-top-right absolute right-0 z-10 mt-2 w-56 rounded-md shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none ${
+            dropdownClassname ?? "bg-black text-white"
+          }`}
+        >
+          <div className="py-1">
+            {options.map((option) => (
+              <button
+                key={option.value}
+                className="block w-full text-left px-4 py-2 text-sm "
+                onClick={() => handleOptionSelect(option.label)}
+              >
+                {option.label}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default Dropdown;

--- a/frontend/src/app/app/Reserve/components/history/history.tsx
+++ b/frontend/src/app/app/Reserve/components/history/history.tsx
@@ -17,7 +17,7 @@ const History = () => {
   }
 
   return (
-    <section className="max-w-[1093px] h-[210px] text-black">
+    <section className="w-full h-[210px] text-black">
       <div className="flex gap-2 mb-4 lg:mb-6">
         <p
           className={`inline-flex py-2 px-3 rounded-[10px] items-center gap-1 font-medium text-xs cursor-pointer ${

--- a/frontend/src/app/app/Reserve/components/history/history.tsx
+++ b/frontend/src/app/app/Reserve/components/history/history.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+import TransactionHistory from "./transactionTab";
+import PositionOverview from "./positionTab";
+
+const History = () => {
+  const [activeTab, setActiveTab] = React.useState("tab1");
+  // render component based on state
+  const handleRenderTab = () => {
+    switch (activeTab) {
+      case "tab1":
+        return <PositionOverview />;
+      case "tab2":
+        return <TransactionHistory />;
+      default:
+        return null;
+    }
+  }
+
+  return (
+    <section className="max-w-[1093px] h-[210px] text-black">
+      <div className="flex gap-2 mb-4 lg:mb-6">
+        <p
+          className={`inline-flex py-2 px-3 rounded-[10px] items-center gap-1 font-medium text-xs cursor-pointer ${
+            activeTab === "tab1" ? "bg-black text-white" : "text-black"
+          }`}
+          onClick={() => setActiveTab("tab1")}
+        >
+          Position Overview
+        </p>
+        <p
+          className={`inline-flex py-2 px-3 rounded-[10px] items-center gap-1 font-medium text-xs cursor-pointer ${
+            activeTab === "tab2" ? "bg-black text-white" : "text-black"
+          }`}
+          onClick={() => setActiveTab("tab2")}
+        >
+          Transaction History
+        </p>
+      </div>
+      {handleRenderTab()}
+    </section>
+  );
+};
+
+export default History;

--- a/frontend/src/app/app/Reserve/components/history/positionTab.tsx
+++ b/frontend/src/app/app/Reserve/components/history/positionTab.tsx
@@ -1,0 +1,104 @@
+const PositionOverview = () => {
+  const data = [
+    {
+      value: 200.34,
+      price: 0.0000004,
+      interest: 0.3,
+      position: "Open",
+    },
+    {
+      value: 200.34,
+      price: 0.0000004,
+      interest: 0.3,
+      position: "Closed",
+    },
+  ];
+
+  return (
+    <div className="overflow-x-auto animate-fadeInBottom">
+      <table className="min-w-full divide-y-2 divide-gray-200 bg-white text-xs">
+        <thead className="bg-black/5 h-[39px] rounded-t-[5px] font-medium text-left">
+          <tr>
+            <th className="whitespace-nowrap px-4 py-2 font-medium text-gray-900">
+              Value
+            </th>
+            <th className="whitespace-nowrap px-4 py-2 font-medium text-gray-900">
+              Price
+            </th>
+            <th className="whitespace-nowrap px-4 py-2 font-medium text-gray-900">
+              Interest
+            </th>
+            <th className="whitespace-nowrap px-4 py-2 font-medium text-gray-900">
+              Position
+            </th>
+            <th className="px-4 py-2"></th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-gray-200 bg-white/5">
+          {data.map((item, index) => (
+            <tr key={index}>
+              <td className="whitespace-nowrap px-4 py-2 flex flex-col font-medium text-gray-900">
+                {item.value.toFixed(2)}M <small>${item.value.toFixed(1)}</small>
+              </td>
+              <td className="whitespace-nowrap px-4 py-2 text-gray-700">
+                ${item.price.toFixed(7)}
+              </td>
+              <td className="whitespace-nowrap px-4 py-2 text-gray-700">
+                {(item.interest * 100).toFixed(1)}%
+              </td>
+              <td
+                className={`whitespace-nowrap px-4 py-2 ${
+                  item.position === "Open" ? "text-green-500" : "text-black/50"
+                }`}
+              >
+                {item.position}
+              </td>
+              <td className="whitespace-nowrap px-4 py-2">
+                <PositionControls
+                  position={item.position as "Open" | "Closed"}
+                  onWithdraw={() => alert("Withdraw")}
+                  onRepay={() => alert("Repay")}
+                />
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default PositionOverview;
+
+interface PositionControlsProps {
+  position: "Open" | "Closed";
+  onWithdraw: () => void;
+  onRepay: () => void;
+}
+
+const PositionControls: React.FC<PositionControlsProps> = ({
+  position,
+  onWithdraw,
+  onRepay,
+}) => {
+  const Button = ({
+    label,
+    onClick,
+  }: {
+    label: string;
+    onClick: () => void;
+  }) => (
+    <button
+      className="bg-black/80 text-white w-[96px] px-5 py-3 rounded-3xl"
+      onClick={onClick}
+    >
+      {label}
+    </button>
+  );
+  return (
+    <div className="flex justify-end">
+      {position === "Open" && <Button label="Withdraw" onClick={onWithdraw} />}
+      {position === "Closed" && <Button label="Repay" onClick={onRepay} />}
+    </div>
+  );
+};

--- a/frontend/src/app/app/Reserve/components/history/positionTab.tsx
+++ b/frontend/src/app/app/Reserve/components/history/positionTab.tsx
@@ -5,19 +5,21 @@ const PositionOverview = () => {
       price: 0.0000004,
       interest: 0.3,
       position: "Open",
+      type: "Lend",
     },
     {
       value: 200.34,
       price: 0.0000004,
       interest: 0.3,
       position: "Closed",
+      type: "Borrow",
     },
   ];
 
   return (
     <div className="overflow-x-auto">
-      <table className="min-w-full divide-y-2 divide-gray-200 bg-white text-xs">
-        <thead className="bg-black/10 h-[39px] rounded-t-[5px] font-medium text-left">
+      <table className="min-w-full bg-white text-xs">
+        <thead className="bg-black/10 h-[39px] rounded-t-[5px] font-medium text-left border border-gray-500">
           <tr>
             <th className="whitespace-nowrap px-4 py-2 font-medium text-gray-900">
               Value
@@ -31,10 +33,13 @@ const PositionOverview = () => {
             <th className="whitespace-nowrap px-4 py-2 font-medium text-gray-900">
               Position
             </th>
+            <th className="whitespace-nowrap px-4 py-2 font-medium text-gray-900">
+              Type
+            </th>
             <th className="px-4 py-2"></th>
           </tr>
         </thead>
-        <tbody className="divide-y divide-gray-200 bg-white/5">
+        <tbody className="divide-y divide-gray-200 bg-white/5 border border-gray-500">
           {data.map((item, index) => (
             <tr key={index}>
               <td className="whitespace-nowrap px-4 py-2 flex flex-col font-medium text-gray-900">
@@ -48,14 +53,18 @@ const PositionOverview = () => {
               </td>
               <td
                 className={`whitespace-nowrap px-4 py-2 ${
-                  item.position === "Open" ? "text-green-500" : "text-black/50"
+                  item.position === "Open" ? "text-green-500" : "text-red-500"
                 }`}
               >
                 {item.position}
               </td>
+              <td className="whitespace-nowrap px-4 py-2 text-gray-700">
+                {item.type}
+              </td>
               <td className="whitespace-nowrap px-4 py-2">
                 <PositionControls
                   position={item.position as "Open" | "Closed"}
+                  type={item.type as "Lend" | "Borrow"}
                   onWithdraw={() => alert("Withdraw")}
                   onRepay={() => alert("Repay")}
                 />
@@ -72,12 +81,14 @@ export default PositionOverview;
 
 interface PositionControlsProps {
   position: "Open" | "Closed";
+  type: "Lend" | "Borrow";
   onWithdraw: () => void;
   onRepay: () => void;
 }
 
 const PositionControls: React.FC<PositionControlsProps> = ({
   position,
+  type,
   onWithdraw,
   onRepay,
 }) => {
@@ -97,8 +108,13 @@ const PositionControls: React.FC<PositionControlsProps> = ({
   );
   return (
     <div className="flex justify-end">
-      {position === "Open" && <Button label="Withdraw" onClick={onWithdraw} />}
-      {position === "Closed" && <Button label="Repay" onClick={onRepay} />}
+      {position === "Open" && type === "Lend" ? (
+        <Button label="Withdraw" onClick={onWithdraw} />
+      ) : position === "Closed" && type === "Borrow" ? (
+        <span>--</span>
+      ) : (
+        <Button label="Repay" onClick={onRepay} />
+      )}
     </div>
   );
 };

--- a/frontend/src/app/app/Reserve/components/history/positionTab.tsx
+++ b/frontend/src/app/app/Reserve/components/history/positionTab.tsx
@@ -15,9 +15,9 @@ const PositionOverview = () => {
   ];
 
   return (
-    <div className="overflow-x-auto animate-fadeInBottom">
+    <div className="overflow-x-auto">
       <table className="min-w-full divide-y-2 divide-gray-200 bg-white text-xs">
-        <thead className="bg-black/5 h-[39px] rounded-t-[5px] font-medium text-left">
+        <thead className="bg-black/10 h-[39px] rounded-t-[5px] font-medium text-left">
           <tr>
             <th className="whitespace-nowrap px-4 py-2 font-medium text-gray-900">
               Value

--- a/frontend/src/app/app/Reserve/components/history/transactionTab.tsx
+++ b/frontend/src/app/app/Reserve/components/history/transactionTab.tsx
@@ -1,0 +1,60 @@
+import React from 'react'
+
+const TransactionHistory = () => {
+    const data = [
+        {
+          type: "Lend",
+          quantity: 200.34,
+          value: 200.4,
+          interest: 0.3,
+        },
+        {
+            type: "Lend",
+            quantity: 200.34,
+            value: 200.4,
+            interest: 0.3,
+          },
+      ];
+  return (
+    <div className="overflow-x-auto animate-fadeInBottom">
+      <table className="min-w-full divide-y-2 divide-gray-200 bg-white text-[10px]">
+        <thead className="bg-black/5 h-[39px] rounded-t-[5px] font-medium text-left">
+          <tr>
+            <th className="whitespace-nowrap px-4 py-2 font-medium text-gray-900">
+              Transaction Type
+            </th>
+            <th className="whitespace-nowrap px-4 py-2 font-medium text-gray-900">
+              Quantity
+            </th>
+            <th className="whitespace-nowrap px-4 py-2 font-medium text-gray-900">
+              Value($)
+            </th>
+            <th className="whitespace-nowrap px-4 py-2 font-medium text-gray-900">
+              Interest
+            </th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-gray-200 bg-white/5 text-xs">
+          {data.map((item, index) => (
+            <tr key={index}>
+              <td className="whitespace-nowrap px-4 py-2 font-medium text-gray-900">
+                {item.type}
+              </td>
+              <td className="whitespace-nowrap px-4 py-2 text-gray-700">
+                {item.quantity}M
+              </td>
+              <td className="whitespace-nowrap px-4 py-2 text-gray-700">
+                ${item.value}%
+              </td>
+              <td className="whitespace-nowrap px-4 py-2 text-gray-700">
+                ${item.interest}%
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+export default TransactionHistory

--- a/frontend/src/app/app/Reserve/components/history/transactionTab.tsx
+++ b/frontend/src/app/app/Reserve/components/history/transactionTab.tsx
@@ -17,8 +17,8 @@ const TransactionHistory = () => {
       ];
   return (
     <div className="overflow-x-auto">
-      <table className="min-w-full divide-y-2 divide-gray-200 bg-white text-[10px]">
-        <thead className="bg-black/10 h-[39px] rounded-t-[5px] font-medium text-left">
+      <table className="min-w-full bg-white text-[10px]">
+        <thead className="bg-black/10 h-[39px] rounded-t-[5px] font-medium text-left border border-gray-500">
           <tr>
             <th className="whitespace-nowrap px-4 py-2 font-medium text-gray-900">
               Transaction Type
@@ -34,7 +34,7 @@ const TransactionHistory = () => {
             </th>
           </tr>
         </thead>
-        <tbody className="divide-y divide-gray-200 bg-white/5 text-xs">
+        <tbody className="divide-y divide-gray-200 bg-white/5 text-xs border border-gray-500">
           {data.map((item, index) => (
             <tr key={index}>
               <td className="whitespace-nowrap px-4 py-2 font-medium text-gray-900">

--- a/frontend/src/app/app/Reserve/components/history/transactionTab.tsx
+++ b/frontend/src/app/app/Reserve/components/history/transactionTab.tsx
@@ -16,9 +16,9 @@ const TransactionHistory = () => {
           },
       ];
   return (
-    <div className="overflow-x-auto animate-fadeInBottom">
+    <div className="overflow-x-auto">
       <table className="min-w-full divide-y-2 divide-gray-200 bg-white text-[10px]">
-        <thead className="bg-black/5 h-[39px] rounded-t-[5px] font-medium text-left">
+        <thead className="bg-black/10 h-[39px] rounded-t-[5px] font-medium text-left">
           <tr>
             <th className="whitespace-nowrap px-4 py-2 font-medium text-gray-900">
               Transaction Type

--- a/frontend/src/app/app/Reserve/components/nav.tsx
+++ b/frontend/src/app/app/Reserve/components/nav.tsx
@@ -1,0 +1,254 @@
+"use client";
+import Image from "next/image";
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import ConnectButton from "@/components/lib/Connect";
+import AddressBar from "@/components/lib/AddressBar";
+import { useAccount } from "@starknet-react/core";
+import { X } from "lucide-react";
+import Dropdown from "./dropdown";
+
+const CHAINS = {
+  SOLANA: {
+    name: "SOLANA",
+    redirectUrl: "https://peerprotocol.xyz/app",
+  },
+  STARKNET: {
+    name: "STARKNET",
+  },
+  XION: {
+    name: "XION",
+    redirectUrl: "https://peerprotocol.xyz/app",
+  },
+};
+
+const options = Object.values(CHAINS).map((chain) => ({
+  label: chain.name.charAt(0).toUpperCase() + chain.name.slice(1).toLowerCase(),
+  value: chain.name,
+}));
+
+const Nav = () => {
+  const { address } = useAccount();
+  const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
+  const [isChainModalOpen, setIsChainModalOpen] = useState(false);
+  const [selectedChain, setSelectedChain] = useState(options[0].label);
+
+  const toggleMobileMenu = () => {
+    setIsMobileMenuOpen(!isMobileMenuOpen);
+  };
+
+  useEffect(() => {
+    if (address === undefined || address === null) {
+      setIsChainModalOpen(true);
+    } else {
+      setIsChainModalOpen(false);
+    }
+  }, [address]);
+
+  const handleChainSelect = (chainName: keyof typeof CHAINS) => {
+    if (chainName === "STARKNET") {
+      setIsChainModalOpen(false);
+    } else {
+      window.location.href = CHAINS[chainName].redirectUrl;
+    }
+  };
+
+  const handleDropdownChange = (value: string) => {
+    setSelectedChain(value);
+  };
+
+  const ChainSelectionModal = () => {
+    if (!isChainModalOpen) return null;
+
+    return (
+      <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+        <div className="w-full max-w-md relative bg-white text-black rounded-3xl px-8 py-4">
+          <button
+            onClick={() => setIsChainModalOpen(false)}
+            className="absolute right-4 top-4"
+          >
+            <X className="h-6 w-6" />
+          </button>
+          <div className="pt-3 pb-4 w-full">
+            <div className="flex flex-col items-center justify-center gap-2 w-full">
+              <h2 className="text-xl font-semibold text-center mb-6">
+                Choose Blockchain
+              </h2>
+              {Object.entries(CHAINS).map(([id, chain]) => {
+                if (id === "STARKNET") {
+                  return (
+                    <div
+                      key={id}
+                      className="flex items-center justify-center gap-4 bg-white border text-black px-6 py-4 rounded-lg w-full hover:bg-black hover:text-white relative"
+                    >
+                      <ConnectButton
+                        text={chain.name}
+                        className="w-full text-center text-[14px] font-medium cursor-pointer"
+                      />
+                      <Image
+                        src="/icons/strk.svg"
+                        height={30}
+                        width={30}
+                        alt="Logo"
+                        className="cursor-pointer h-[20px] w-[20px] absolute md:right-1/3 right-[20%]"
+                      />
+                    </div>
+                  );
+                }
+                return (
+                  <div
+                    key={id}
+                    onClick={() => handleChainSelect(id as keyof typeof CHAINS)}
+                    className="flex items-center justify-center gap-4 bg-white border text-black text-[14px] px-6 py-4 rounded-lg w-full hover:bg-black hover:text-white"
+                  >
+                    {chain.name}
+                    {id === "SOLANA" ? (
+                      <Image
+                        src="/icons/solanaLogoMark.svg"
+                        height={80}
+                        width={80}
+                        alt="SolanaLogo"
+                        className="cursor-pointer h-[20px] w-[20px]"
+                      />
+                    ) : (
+                      <Image
+                        src="/icons/xionLogo.png"
+                        height={80}
+                        width={80}
+                        alt="XionLogo"
+                        className="cursor-pointer h-[20px] w-[20px]"
+                      />
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  };
+
+  return (
+    <nav className="flex justify-end items-center p-4 w-full gap-3">
+      {/* Logo for mobile */}
+      <div className="md:hidden flex">
+        <Image
+          src="/images/LogoBlack.svg"
+          height={30}
+          width={30}
+          alt="Logo"
+          className="cursor-pointer"
+        />
+      </div>
+
+      {/* Notification icon hidden on mobile */}
+      <div className="hidden md:block">
+        <Image
+          src="/images/notification.svg"
+          height={40}
+          width={40}
+          alt="Notification icon"
+          className="ml-4 bg-black/80 rounded-full"
+        />
+      </div>
+
+      <div className="relative">
+        <Dropdown
+          options={options}
+          selected={selectedChain}
+          selectedClassname="bg-black/80 text-white"
+          dropdownClassname="bg-black/80 text-white"
+          onSelect={handleDropdownChange}
+        />
+      </div>
+
+      <div className="relative">
+        {address ? (
+          <div className="flex items-center gap-4">
+            <AddressBar />
+          </div>
+        ) : (
+          <button
+            onClick={() => setIsChainModalOpen(true)}
+            className="border border-black px-6 py-2 rounded-3xl text-black"
+          >
+            Connect Wallet
+          </button>
+        )}
+      </div>
+
+      {/* Mobile nav toggle */}
+      <div className="lg:hidden flex items-center gap-4">
+        <button onClick={toggleMobileMenu}>
+          <Image
+            src="/icons/menu.svg"
+            height={30}
+            width={30}
+            alt="Mobile Menu"
+          />
+        </button>
+      </div>
+
+      {/* Mobile Menu */}
+      {isMobileMenuOpen && (
+        <div className="top-2 fixed mx-auto w-[98%] h-[fit-content] bg-white text-black  z-50 flex flex-col rounded-md p-2">
+          <div className="w-full bg-[#efefef] flex flex-col gap-4 p-4 items-start text-left rounded-lg">
+            <button onClick={toggleMobileMenu} className="self-end mb-4">
+              <Image
+                src="/icons/close.svg"
+                height={30}
+                width={30}
+                alt="Close Menu"
+              />
+            </button>
+
+            <ul className="flex flex-col items-start gap-6 text-lg text-left">
+              <Link href="/app">
+                <li className="flex gap-2">
+                  <Image
+                    src="/images/institution.svg"
+                    height={30}
+                    width={30}
+                    alt="Notification icon"
+                    className=""
+                  />
+                  Market
+                </li>
+              </Link>
+              <Link href="/profile">
+                <li className="flex gap-2">
+                  <Image
+                    src="/images/portfolio.svg"
+                    height={30}
+                    width={30}
+                    alt="Notification icon"
+                    className=""
+                  />
+                  Dashboard
+                </li>
+              </Link>
+              <Link href="/app/quests">
+                <li className="flex gap-2">
+                  <Image
+                    src="/icons/quests.svg"
+                    height={30}
+                    width={30}
+                    alt="Notification icon"
+                    className=""
+                  />
+                  Quests
+                </li>
+              </Link>
+            </ul>
+          </div>
+        </div>
+      )}
+
+      {/* Chain Selection Modal */}
+      <ChainSelectionModal />
+    </nav>
+  );
+};
+
+export default Nav;

--- a/frontend/src/app/app/Reserve/components/sidebar.tsx
+++ b/frontend/src/app/app/Reserve/components/sidebar.tsx
@@ -1,0 +1,111 @@
+import Image from "next/image";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+const Sidebar = () => {
+  const pathname = usePathname();
+  const showQuestLinks = pathname.startsWith("/app/quests");
+
+  return (
+    <div className="bg-black w-[15%] h-screen rounded-r-[2.5rem] py-8 hidden text-white lg:flex flex-col sticky top-0">
+      <Image
+        className="mx-[30%]"
+        src="/images/LogoWhite.svg"
+        width={50}
+        height={20}
+        alt="Logo"
+      />
+      <div className="mt-14 px-10 flex-1 flex flex-col">
+        <div className="flex flex-col gap-14 flex-grow">
+          <Link href='/app' className="flex gap-3 items-center cursor-pointer">
+            <Image
+              src="/images/LogoWhite.svg"
+              width={30}
+              height={10}
+              alt="Market"
+            />
+            <p>Market</p>
+          </Link>
+          <Link href='/app/profile' className="flex gap-3 items-center cursor-pointer">
+            <Image
+              src="/images/drop-of-liquid.svg"
+              width={30}
+              height={10}
+              alt="Liquidity"
+            />
+            <p>Liquidity</p>
+          </Link>
+          <Link href='' type="disabled" className="flex gap-3 items-center cursor-pointer">
+            <Image
+              src="/images/reverse-arrow.svg"
+              width={30}
+              height={10}
+              alt="swap"
+            />
+            <p>Swap</p>
+          </Link>
+
+          <Link href="/app/quests">
+                <li className="flex gap-2">
+                    <Image
+                    src="/images/dashboard.svg"
+                    height={30}
+                    width={30}
+                    alt="portfolio icon"
+                    className=""
+                    />
+                    Portfolio
+                </li>
+            </Link>
+
+          <Link href="/app/quests">
+                <li className="flex gap-2 text-nowrap">
+                    <Image
+                    src="/images/asset-allocation.svg"
+                    height={30}
+                    width={30}
+                    alt="asset icon"
+                    className=""
+                    />
+                    Asset manager
+                </li>
+            </Link>
+
+          {showQuestLinks && (
+            <>
+              <Link href='/app/quests/referral' className="flex gap-3 items-center cursor-pointer">
+                <Image
+                  src="/icons/referral.svg"
+                  width={30}
+                  height={10}
+                  alt="Referral"
+                />
+                <p>Referral</p>
+              </Link>
+              <Link href='/app/quests/leaderboard' className="flex gap-3 items-center cursor-pointer">
+                <Image
+                  src="/icons/leaderboard.svg"
+                  width={30}
+                  height={10}
+                  alt="Leaderboard"
+                />
+                <p>Leaderboard</p>
+              </Link>
+              <Link href='/app/quests/socials' className="flex gap-3 items-center cursor-pointer">
+                <Image
+                  src="/icons/social.svg"
+                  width={30}
+                  height={10}
+                  alt="Social Quests"
+                />
+                <p>Social Quests</p>
+              </Link>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Sidebar;

--- a/frontend/src/app/app/Reserve/page.tsx
+++ b/frontend/src/app/app/Reserve/page.tsx
@@ -1,8 +1,6 @@
 "use client";
 import Sidebar from "./components/sidebar";
 import Dashboard from "./components/dashboard";
-import Market from "../market";
-import Footer from "../footer";
 import Nav from "./components/nav";
 import { reserveDashboardData } from "@/data/reserveDashboardData";
 
@@ -15,8 +13,6 @@ export default function Home() {
             <Nav/>
             <main className="flex-1 p-4 lg:p-14">
               <Dashboard tokenReserved={reserveDashboardData[2]}/>
-              <Market />
-              <Footer />
             </main>
           </div>
         </div>

--- a/frontend/src/app/app/Reserve/page.tsx
+++ b/frontend/src/app/app/Reserve/page.tsx
@@ -11,7 +11,7 @@ export default function Home() {
           <Sidebar />
           <div className="flex-1 flex flex-col h-full max-h-screen overflow-auto">
             <Nav/>
-            <main className="flex-1 p-4 lg:p-14">
+            <main className="flex-1 p-4 lg:pl-14">
               <Dashboard tokenReserved={reserveDashboardData[2]}/>
             </main>
           </div>

--- a/frontend/src/app/app/Reserve/page.tsx
+++ b/frontend/src/app/app/Reserve/page.tsx
@@ -11,7 +11,7 @@ export default function Home() {
           <Sidebar />
           <div className="flex-1 flex flex-col h-full max-h-screen overflow-auto">
             <Nav/>
-            <main className="flex-1 p-4 lg:pl-14">
+            <main className="flex-1 p-4 lg:px-14">
               <Dashboard tokenReserved={reserveDashboardData[2]}/>
             </main>
           </div>

--- a/frontend/src/app/app/Reserve/page.tsx
+++ b/frontend/src/app/app/Reserve/page.tsx
@@ -1,0 +1,25 @@
+"use client";
+import Sidebar from "./components/sidebar";
+import Dashboard from "./components/dashboard";
+import Market from "../market";
+import Footer from "../footer";
+import Nav from "./components/nav";
+import { reserveDashboardData } from "@/data/reserveDashboardData";
+
+export default function Home() {
+  return (
+    <main className="bg-[#F5F5F5]">
+        <div className="flex h-screen">
+          <Sidebar />
+          <div className="flex-1 flex flex-col h-full max-h-screen overflow-auto">
+            <Nav/>
+            <main className="flex-1 p-4 lg:p-14">
+              <Dashboard tokenReserved={reserveDashboardData[2]}/>
+              <Market />
+              <Footer />
+            </main>
+          </div>
+        </div>
+    </main>
+  );
+}

--- a/frontend/src/data/reserveDashboardData.ts
+++ b/frontend/src/data/reserveDashboardData.ts
@@ -1,0 +1,38 @@
+export const reserveDashboardData = [
+    {
+        id: 1,
+        icon: "/icons/strk.svg",
+        symbol: "STRK",
+        address: "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
+        decimals: 18,
+        balance: 50,
+        availableLiquidity: "0",
+        supply: "0",
+        utilization: "0",
+        totalBorrowed: "0",
+    },
+    {
+        id: 2,
+        icon: "/icons/eth.svg",
+        symbol: "ETH",
+        address: "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
+        decimals: 18,
+        balance: 0.01,
+        availableLiquidity: "0",
+        supply: "0",
+        utilization: "0",
+        totalBorrowed: "0",
+    },
+    {
+        id: 3,
+        icon: "/images/usdc.png",
+        symbol: "USDC",
+        address: "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
+        decimals: 18,
+        balance: 20.6374,
+        availableLiquidity: "20.43M",
+        supply: "20.43M",
+        utilization: "53.02%",
+        totalBorrowed: "500.23B",
+    }
+]

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -16,10 +16,15 @@ const config: Config = {
           '0%, 100%': { transform: 'rotate(0deg)' },
           '25%': { transform: 'rotate(-60deg)' },
           '75%': { transform: 'rotate(60deg)' },
+        },
+        fadeInBottom: {
+          '0%': { opacity: '0', transform: 'translateY(20px)' },
+          '100%': { opacity: '1', transform: 'translateY(0)' },
         }
       },
       animation: {
         shake: 'shake 1s ease-in-out infinite',
+        fadeInBottom: 'fadeInBottom 1s ease-in-out',
       },
       fontFamily: {
         redhat: ['Red Hat Display', 'sans-serif'],


### PR DESCRIPTION
Title: Reserve Dashboard UI Implementation.
Description: Make sidebar component for the layout, make the dashboard ui section that includes working with displaying necessary data in grid card style, made a protocol component for `Supply` and `Borrow`. Integrated `recharts` for the chart ui with custom rendering in some element to achieve desired result similar to the design. Code split the history ui into three components, parent and two child components, the two child components handle the `position overview` & `transaction history`. All functionality on each component built for reserve dashboard ui is set. Lastly, added some animation on the history ui and card component text.
Issue Reference: Close #104 
Screenshots: 
![image](https://github.com/user-attachments/assets/0920bdb2-ab9a-4208-8eb4-67db6acfa3de)
![image](https://github.com/user-attachments/assets/70e1aee4-e49b-49bf-94cb-821a9f91f103)
![image](https://github.com/user-attachments/assets/571c609f-d909-4967-b2e9-7eb69b1d6390)
![image](https://github.com/user-attachments/assets/4f354f62-9982-482a-8359-7f2afd8f5821)
