### PR TITLE
Lender locked balance is now unlocked after repaying loan

### DIFF
--- a/contracts/src/peer_protocol.cairo
+++ b/contracts/src/peer_protocol.cairo
@@ -1179,14 +1179,14 @@ pub mod PeerProtocol {
                 spok.burn(proposal.borrower_nft_id);
 
                 // Unlock lenders locked tokens
-             let locked_funds = self
-             .locked_funds
-             .entry((proposal.lender, proposal.token))
-             .read();
-         self
-             .locked_funds
-             .entry((proposal.lender, proposal.token))
-             .write(locked_funds - proposal.token_amount);
+                let locked_funds = self
+                    .locked_funds
+                    .entry((proposal.lender, proposal.token))
+                    .read();
+                self
+                    .locked_funds
+                    .entry((proposal.lender, proposal.token))
+                    .write(locked_funds - net_amount_in_tokens);
 
                 self
                     .emit(

--- a/contracts/src/peer_protocol.cairo
+++ b/contracts/src/peer_protocol.cairo
@@ -1125,7 +1125,7 @@ pub mod PeerProtocol {
             );
 
             IERC20Dispatcher { contract_address: proposal.token }
-                .transfer(proposal.lender, repayment_amount_with_interest_in_tokens);
+                .transfer_from(caller, proposal.lender, repayment_amount_with_interest_in_tokens);
 
             // Calculate collateral release amount
             let (_, collateral_decimals) = self.get_token_price(proposal.accepted_collateral_token);


### PR DESCRIPTION
gm ! This PR fixes the `repay_proposal` function and passes the `test_repay_proposal`.
Here's what I did:
- I found that when a borrow proposal is accepted, the lender’s tokens weren't locked, allowing lenders to withdraw funds that had already been borrowed. This also caused repayment issues. I fixed this by locking the lender’s tokens when a borrow proposal is accepted. (the lending proposal already contained the correct locking logic)
- Updated the repay_proposal function to correctly transfer tokens from the borrower to the lender
- Updated the repay_proposal function to unlock the correct net token amount for the lender instead of subtracting the full token amount
- Modified the repay_proposal test to ensure that full repayment is triggered

Let me know if any changes are needed. Thanks!