### PR TITLE
Invert logo colors on dark-theme

### DIFF
--- a/frontend/src/components/LandingPage/HeroSection.tsx
+++ b/frontend/src/components/LandingPage/HeroSection.tsx
@@ -78,22 +78,22 @@ const HeroPage = () => {
               src="/images/solanalogo.svg"
               width={200}
               height={0}
-              alt=""
-              className="w-16 lg:w-64 md:w-32"
+              alt="Solana Logo"
+              className={`w-16 lg:w-64 md:w-32 ${isDarkMode ? "brightness-0 invert" : ""}`}
             />
             <Image
               src="/images/xionlogo.svg"
               width={200}
               height={0}
-              alt=""
-              className="w-16 lg:w-64 md:w-32"
+              alt="Xion Logo"
+              className={`w-16 lg:w-64 md:w-32 ${isDarkMode ? "brightness-0 invert" : ""}`}
             />
             <Image
               src="/images/starknetlogo.svg"
               width={200}
               height={0}
-              alt=""
-              className="w-16 lg:w-64 md:w-32"
+              alt="Starknet Logo"
+              className={`w-16 lg:w-64 md:w-32 ${isDarkMode ? "invert hue-rotate-180" : ""}`}
             />
           </div>
         </div>


### PR DESCRIPTION
In this PR I fix the display of the logos on the dark-theme, which Fixes #173 

Changes:
- inverting colors of logos 

Demo:
<img width="1440" alt="Screenshot 2025-03-12 at 10 04 51 AM" src="https://github.com/user-attachments/assets/8916ecc8-daee-416e-8ae6-61ec24bb871e" />

PS: I found this approach to be the easiest and most consistent with the rest of the code.